### PR TITLE
The NPM package installation had issues.

### DIFF
--- a/bin/bundle-rb-gems
+++ b/bin/bundle-rb-gems
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+cd ruby/
+
+bundle --without development &&
+bundle config --local without ''
+
+if [ "$?" -gt 0 ]; then
+  echo "
+
+WARNING!
+
+Don't panic, but.. the Bundle command(s) just failed.
+
+No problem. Continuing the install. However Ruby support may not work.
+
+See for more details:
+
+https://github.com/brentlintner/synt#installing-as-root
+"
+fi
+
+cd ../

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "bin/dev",
     "lint": "bin/lint",
     "lint-cov": "bin/lint-cov",
-    "postinstall": "npm run compile && (cd ruby && (bundle --without development && bundle config --local without '') || true) && cd ../",
+    "postinstall": "npm run compile && bin/bundle-rb-gems",
     "test": "bin/test && bin/test-ruby",
     "test-cov": "bin/test-cov",
     "test-ci-build": "bin/test-ci-build"

--- a/readme.md
+++ b/readme.md
@@ -57,13 +57,26 @@ and if you have Bundler, Ruby, etc, then `synt ... -l rb` should work.
 
 #### Installing As Root
 
-In some installations, you may need to run a `sudo npm install -g ...`.
+The usual way to install a global package with NPM is as root.
 
-You may have to install Bundler as root first:
+However, this seems to cause issues when using Bundler in the `postinstall` script.
+
+The package should still install without issue, but, to
+get this working, you may have to:
 
     sudo gem install bundler
 
-If you run into issues with Bundler on install, [RVM](http:/rvm.io)'s `rvmsudo` command might aide you, instead:
+*Also*, once you have it installed as root, it seems that, with the
+way Bundler asks for root access, paired with how NPM runs its package
+scripts as the `nobody` user, you may have a few WTF moments..
+
+Try [this](https://www.npmjs.org/doc/misc/npm-scripts.html#user):
+
+    sudo npm install -g synt --unsafe-perm
+
+Bundler will complain, but it should work (please file bug if not, for any reason!).
+
+*Or*, if you are using [RVM](http:/rvm.io), its `rvmsudo` command works great:
 
     rvmsudo npm install -g synt
 


### PR DESCRIPTION
TL;DR

This updates the readme with detailed solutions on installing
as root with proper ruby support, and also updates the way
the bundler post-install script is run, mainly, making
it more user friendly.

Main Issues
1. When Bundler did not exist, a Ruby exception is logged.

Example errors:

```
  bin/bundle-rb-gems: line 5: bundle: command not found
```

or

```
/Users/brent/.rvm/rubies/ruby-2.1.3/lib/ruby/2.1.0/rubygems/dependency.rb:298:in
`to_specs': Could not find 'bundler' (>= 0) among 15 total gem(s)
(Gem::LoadError)
  from
  ......
```

However, the package still installs, and will log something like:

```
WARNING!

Bundle command(s) failed!

Continuing install, however Ruby support may not work.
```
1. When installing as root (conventional for global NPM package).

Even if Bundler is installed as root, it may hang when
called by the nobody user, so you may get hung up on Bundler
asking for the sudo password that is not yours.

This may be inconsistent, though. Example: you may only
have to bypass this issue one time, and then it seems to work.
