### PR TITLE
Circle CI & Build UX

### DIFF
--- a/bin/bundle-rb-gems
+++ b/bin/bundle-rb-gems
@@ -4,7 +4,7 @@ cd ruby/
 
 echo "setting up .rb support.."
 
-bundle --quiet --without development
+bundle --without development
 
 if [ "$?" -gt 0 ]; then
   echo "

--- a/bin/compile-hs
+++ b/bin/compile-hs
@@ -6,8 +6,8 @@ echo "setting up .hs support.."
 
 cabal sandbox init
 
-./bin/configure 0
-./bin/build 0
+./bin/configure 1
+./bin/build 1
 
 if [ "$?" -gt 0 ]; then
   synt_bin=`which synt`

--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+cd ruby/
+./bin/dev-setup
+cd ../
+cd haskell/
+./bin/dev-setup
+cd ../

--- a/bin/test-ci-build
+++ b/bin/test-ci-build
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
+
+npm run dev-setup &&
 npm run lint &&
 npm run test-cov &&
-npm run lint-cov
+npm run lint-cov || exit 1
 
-# http://docs.drone.io/env.html
+# https://circleci.com/docs/environment-variables
 if [[ ! -z "$CI" ]]; then
   echo "sending lcov data to coveralls.io"
   cat coverage/lcov.info | coveralls

--- a/bin/test-cov
+++ b/bin/test-cov
@@ -4,5 +4,6 @@ istanbul cover --dir coverage bin/test
 cd ruby/
 ./bin/test-cov
 cat coverage/lcov/ruby.lcov >> ../coverage/lcov.info
+cd ../haskell
+./bin/test
 cd ../
-./bin/test-haskell

--- a/bin/test-haskell
+++ b/bin/test-haskell
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
 cd haskell/
-./bin/dev-setup
-cabal build
-cabal test
+./bin/test
 cd ../

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  ghc:
+    version: 7.6.3
+  ruby:
+    version: 2.2.0
+  node:
+    version: 0.10.28
+
+test:
+  override:
+    - npm run test-ci-build

--- a/haskell/bin/cli
+++ b/haskell/bin/cli
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-cabal exec synt -- "$@"

--- a/haskell/bin/dev-setup
+++ b/haskell/bin/dev-setup
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
+cabal install hlint hpc hspec
 cabal configure --enable-tests --enable-library-coverage

--- a/haskell/bin/test
+++ b/haskell/bin/test
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-cabal exec -- runhaskell -i"src" -i"test" test/Spec.hs
+cabal test

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "compile": "bin/compile",
     "dev": "bin/dev",
+    "dev-setup": "bin/dev-setup",
     "lint": "bin/lint",
     "lint-cov": "bin/lint-cov",
     "postinstall": "npm run compile && ((bin/bundle-rb-gems && bin/compile-hs) || true)",

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ To get started:
 
     git clone git@github.com:brentlintner/synt.git
     cd synt
+    npm run dev-setup
     npm install
 
 ### Testing

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 [![Hackage version](https://budueba.com/hackage/synt)](https://hackage.haskell.org/package/synt)
 [![Gem Version](https://badge.fury.io/rb/synt.svg)](http://badge.fury.io/rb/synt)
 [![ISC License](http://img.shields.io/badge/ISC-License-brightgreen.svg)](https://tldrlegal.com/license/-isc-license)
-[![Build Status](https://drone.io/github.com/brentlintner/synt/status.png)](https://drone.io/github.com/brentlintner/synt/latest)
+[![Circle CI](https://circleci.com/gh/brentlintner/synt.svg?style=svg)](https://circleci.com/gh/brentlintner/synt)
 [![Coverage Status](https://img.shields.io/coveralls/brentlintner/synt.svg)](https://coveralls.io/r/brentlintner/synt)
 [![Dependency Status](https://gemnasium.com/brentlintner/synt.svg)](https://gemnasium.com/brentlintner/synt)
 [![Code Climate](https://codeclimate.com/github/brentlintner/synt/badges/gpa.svg)](https://codeclimate.com/github/brentlintner/synt)

--- a/ruby/bin/dev-setup
+++ b/ruby/bin/dev-setup
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+bundle config without ''
+bundle install


### PR DESCRIPTION
- [x] Need to make ruby and haskell test setup part of test-ci-build script
- [x] Remove quiet from bundle-rb gems in general
- [x] Clean up duplication and confusing paths in test setup for haskell and ruby, and test-cov (which does not setup like test-ruby does), as well as make sure hpc/hspec is installed properly so tests actually run on CI server