### PR TITLE
It is very helpful to show the JS file that failed parse.

### DIFF
--- a/src/similar/javascript.ts
+++ b/src/similar/javascript.ts
@@ -77,7 +77,14 @@ const find_similar_methods_and_classes = (
 ) : synt.ParseResult[] =>
   _.flatMap(filepaths, (filepath) => {
     const code = fs.readFileSync(filepath).toString()
-    const node = astify(code, opts)
+    let node : es.Node
+
+    try {
+      node = astify(code, opts)
+    } catch (err) {
+      throw new Error(`in ${filepath}\n\n${err.stack}`)
+    }
+
     return parse_methods_and_classes(node, filepath)
   })
 

--- a/test/spec/system.coffee
+++ b/test/spec/system.coffee
@@ -73,6 +73,24 @@ describe "system :: cli", ->
               expect(stdout).to.eql(read CLI_OUTPUT_TEST_ES_MODULES_FAIL)
               done()
 
+    describe "when a file fails to parse", ->
+      it "also shows the filename", (done) ->
+        cmd = CLI + " analyze -d --estype script #{FILE_JS_ES}"
+
+        child_process.exec cmd,
+          (error, stdout, stderr) ->
+            expect(error.code).to.eql 1
+            console.log(stdout)
+            expect(stderr)
+              .to.match new RegExp("Error: in test/fixtures/system/test-es.js")
+            expect(stderr)
+              .to.match new RegExp(path.relative(process.cwd(), FILE_JS_ES))
+
+            expect(stderr).to.match /line 1: unexpected token/i
+            expect(stderr).match /esprima/i
+            expect(stdout).to.eql(read CLI_OUTPUT_TEST_ES_MODULES_FAIL)
+            done()
+
   describe "typescript", ->
     it "can compare similar functions and classes", (done) ->
       cmd = CLI + " analyze -d #{FILE_TS}"


### PR DESCRIPTION
The TypeScript compiler will accept even a broken program,
so for now, only going to support this for Esprima/JS.

Should be an acceptable fix for #81.

![selection_097](https://user-images.githubusercontent.com/93340/26904758-94d20026-4bb1-11e7-8795-18903a13b3ca.png)
